### PR TITLE
Update express to 4.16.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "cors": "^2.8.4",
     "debug": "^3.0.0",
-    "express": "~4.13.1",
+    "express": "^4.16.3",
     "http-proxy": "^1.17.0",
     "netmask": "^1.0.6",
     "request": "^2.83.0",


### PR DESCRIPTION
Update express to address the following vulnerabilities
* https://nodesecurity.io/advisories/106
* https://nodesecurity.io/advisories/526
* https://nodesecurity.io/advisories/534
* https://nodesecurity.io/advisories/535