### PR TITLE
Fix: console.err -> console.error

### DIFF
--- a/src/routes/resize.js
+++ b/src/routes/resize.js
@@ -23,7 +23,7 @@ RoutesResize.proxy = (req, res) => {
     }).then((buf) => {
         res.send(buf);
     }).catch(err => {
-        console.err(err);
+        console.error(err);
         return res.status(400).send({ error: { code: 'RESIZE_ERROR', message: 'Invalid parameters, resize request fails' } });
     });
 }


### PR DESCRIPTION
Seems like typo... found because of problems with DNS resolution, error was not properly shown in console...

```
loadbalancer_1  | (node:25) UnhandledPromiseRejectionWarning: TypeError: _38e‍.g.console.err is not a function
loadbalancer_1  |     at /opt/UnicornLoadBalancer/src/routes/resize.js:26:25
loadbalancer_1  |     at processTicksAndRejections (internal/process/task_queues.js:97:5)
loadbalancer_1  | (node:25) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
loadbalancer_1  | (node:25) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```